### PR TITLE
support pre-release gem versions

### DIFF
--- a/src/__tests__/fixtures/invalid-version-file/lib/test-gem/version.rb
+++ b/src/__tests__/fixtures/invalid-version-file/lib/test-gem/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module TestGem
+  SOME_CONST = '1.1.2'
+end

--- a/src/__tests__/fixtures/invalid-version-file/test-gem.gemspec
+++ b/src/__tests__/fixtures/invalid-version-file/test-gem.gemspec
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'test-gem/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'a-test-gem'
+  spec.version       = TestGem::SOME_CONST
+  spec.authors       = ['Rylan Collins']
+  spec.summary       = 'A gem for testing'
+end

--- a/src/__tests__/fixtures/prerelease/lib/test-gem/version.rb
+++ b/src/__tests__/fixtures/prerelease/lib/test-gem/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module TestGem
+  VERSION = '0.1.0.alpha.1'
+end

--- a/src/__tests__/fixtures/prerelease/test-gem.gemspec
+++ b/src/__tests__/fixtures/prerelease/test-gem.gemspec
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'test-gem/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'a-test-gem'
+  spec.version       = TestGem::VERSION
+  spec.authors       = ['Rylan Collins']
+  spec.summary       = 'A gem for testing'
+end

--- a/src/__tests__/prepare.test.js
+++ b/src/__tests__/prepare.test.js
@@ -44,6 +44,23 @@ end
 `);
 });
 
+describe('when the version.rb contains a prerelease version', () => {
+  it('writes the new version to the version.rb file', async () => {
+    await prepare(
+      {},
+      { ...context, nextRelease: { version: '1.0.0-alpha.1' } },
+      { versionFile, gemspec, gemName },
+    );
+    const versionContents = await readFile(path.resolve(cwd, versionFile), 'utf8');
+    expect(versionContents).toEqual(`# frozen_string_literal: true
+
+module TestGem
+  VERSION = '1.0.0-alpha.1'
+end
+`);
+  });
+});
+
 describe('when updateGemfileLock is set to `true`', () => {
   it('runs `bundle install`', async () => {
     await writeFile(path.resolve(cwd, 'Gemfile'), "source 'https://rubygems.org'\ngemspec", 'utf8');

--- a/src/__tests__/verifyConditions.test.js
+++ b/src/__tests__/verifyConditions.test.js
@@ -66,6 +66,17 @@ describe('when there is no version file', () => {
   });
 });
 
+describe('when no version can be found in the version file', () => {
+  it('throws an error', async () => {
+    const cwd = path.resolve(__dirname, './fixtures/invalid-version-file');
+    await expect(
+      verifyConditions({}, { cwd, env: defaultEnv }, { credentialsFile }),
+    ).rejects.toThrow(
+      /^Couldn't find a valid version constant defined in `lib\/test-gem\/version.rb`.$/,
+    );
+  });
+});
+
 it('creates the credentials file', async () => {
   await verifyConditions({}, { cwd: validCwd, env: defaultEnv }, { credentialsFile });
   const credentialsContents = await readFile(credentialsFile, 'utf8');

--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,2 @@
+// taken from https://github.com/svenfuchs/gem-release/blob/0f5f2382ef960d40169400a8aa25085cd37d26b0/lib/gem/release/files/version.rb#L7
+module.exports.VERSION_REGEX = /(VERSION\s*=\s*['"])(?:(?!"|').)*(['"])/;

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -8,7 +8,6 @@ const writeVersion = async ({ versionFile, nextVersion, logger, cwd }) => {
   const versionContents = await readFile(fullVersionPath, 'utf8');
   const newContents = versionContents.replace(VERSION_REGEX, `$1${nextVersion}$2`);
   logger.log('Writing version %s to `%s`', nextVersion, versionFile);
-  // TODO: Check to insure the contents changed. Or, maybe verify the format of the version in verify?
   await writeFile(fullVersionPath, newContents, 'utf8');
 };
 

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -7,7 +7,8 @@ const writeVersion = async ({ versionFile, nextVersion, logger, cwd }) => {
   const versionContents = await readFile(fullVersionPath, 'utf8');
   const newContents = versionContents.replace(
     /(VERSION = ['"])[0-9.]*(['"])/,
-    `$1${nextVersion}$2`,
+    // see https://guides.rubygems.org/patterns/#prerelease-gems
+    `$1${nextVersion.replace('-', '.')}$2`,
   );
   logger.log('Writing version %s to `%s`', nextVersion, versionFile);
   // TODO: Check to insure the contents changed. Or, maybe verify the format of the version in verify?

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -6,7 +6,8 @@ const writeVersion = async ({ versionFile, nextVersion, logger, cwd }) => {
   const fullVersionPath = path.resolve(cwd, versionFile);
   const versionContents = await readFile(fullVersionPath, 'utf8');
   const newContents = versionContents.replace(
-    /(VERSION = ['"])[0-9.]*(['"])/,
+    // taken from https://github.com/svenfuchs/gem-release/blob/0f5f2382ef960d40169400a8aa25085cd37d26b0/lib/gem/release/files/version.rb#L7
+    /(VERSION\s*=\s*['"])(?:(?!"|').)*(['"])/,
     // see https://guides.rubygems.org/patterns/#prerelease-gems
     `$1${nextVersion.replace('-', '.')}$2`,
   );

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -1,16 +1,12 @@
 const { readFile, writeFile } = require('fs').promises;
 const path = require('path');
 const execa = require('execa');
+const { VERSION_REGEX } = require('./common');
 
 const writeVersion = async ({ versionFile, nextVersion, logger, cwd }) => {
   const fullVersionPath = path.resolve(cwd, versionFile);
   const versionContents = await readFile(fullVersionPath, 'utf8');
-  const newContents = versionContents.replace(
-    // taken from https://github.com/svenfuchs/gem-release/blob/0f5f2382ef960d40169400a8aa25085cd37d26b0/lib/gem/release/files/version.rb#L7
-    /(VERSION\s*=\s*['"])(?:(?!"|').)*(['"])/,
-    // see https://guides.rubygems.org/patterns/#prerelease-gems
-    `$1${nextVersion.replace('-', '.')}$2`,
-  );
+  const newContents = versionContents.replace(VERSION_REGEX, `$1${nextVersion}$2`);
   logger.log('Writing version %s to `%s`', nextVersion, versionFile);
   // TODO: Check to insure the contents changed. Or, maybe verify the format of the version in verify?
   await writeFile(fullVersionPath, newContents, 'utf8');

--- a/src/verifyConditions.js
+++ b/src/verifyConditions.js
@@ -24,7 +24,6 @@ Please follow the "[Make your own gem guide](https://guides.rubygems.org/make-yo
   const [gemspec] = gemspecs;
   let gemName = null;
   try {
-    // TODO: Use cwd here instead of the full path?
     const { stdout } = await execa(
       'ruby',
       ['-e', `puts Gem::Specification.load('${gemspec}').name`],


### PR DESCRIPTION
rubygems expect versions that look like `1.0.0.alpha`, while semantic versions are `1.0.0-alpha`