### PR TITLE
feat: allow GEM_HOST_API_KEY to be used for any gemHost

### DIFF
--- a/src/publish.js
+++ b/src/publish.js
@@ -8,7 +8,7 @@ module.exports = async function publish(
 ) {
   if (gemPublish !== false) {
     logger.log(`Publishing version ${version} to gem server`);
-    const args = ['push', gemFile, '--config-file', credentialsFile];
+    const args = ['push', gemFile, '--config-file', credentialsFile, '--key', 'api_key'];
     if (gemHost) {
       args.push('--host', gemHost);
     }

--- a/src/verifyConditions.js
+++ b/src/verifyConditions.js
@@ -100,8 +100,7 @@ You can retrieve an API key either from your \`~/.gem/credentials\` file or in y
 
   await writeFile(
     credentialsFile,
-    // TODO: Handle other hosts
-    `---\n:rubygems_api_key: ${env.GEM_HOST_API_KEY}`,
+    `---\n:api_key: ${env.GEM_HOST_API_KEY}`,
     'utf8',
   );
 };


### PR DESCRIPTION
This allows using different hosts with `gemHost` while using `GEM_HOST_API_KEY`. This allowed me to push to gemfury.com with their push key.

The `--key` is described as:

> Use the given API key from .../gem/credentials

In this PR the key is set to a static value, so that whichever `gemHost` was supplied, the key from `GEM_HOST_API_KEY` is always used.