### PR TITLE
chore(deps): bump allowed version for semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "version"
   ],
   "engines": {
-    "node": ">=10.18"
+    "node": ">=14.17"
   },
   "files": [
     "LICENSE",
@@ -49,6 +49,6 @@
     "tempy": "^0.5.0"
   },
   "peerDependencies": {
-    "semantic-release": ">=16.0.0 <18.0.0"
+    "semantic-release": ">=16.0.0 <19.0.0"
   }
 }


### PR DESCRIPTION
This PR bumps the peerDependency for semantic-release to allow for v18.x, which is the latest revision of semantic-release

The associated breaking change: https://github.com/semantic-release/semantic-release/pull/2132