### PR TITLE
Remove upper bound on semantic-release peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "tempy": "^0.5.0"
   },
   "peerDependencies": {
-    "semantic-release": ">=16.0.0 <18.0.0"
+    "semantic-release": ">=16.0.0"
   }
 }


### PR DESCRIPTION
Resolves:

> warning " > semantic-release-rubygem@1.2.0" has incorrect peer dependency "semantic-release@>=16.0.0 <18.0.0".

Seen [here](https://buildkite.com/gusto/gusto-sorbet/builds/361#019a5c32-b937-4a68-a163-6850f15cfee7/7-79), where publishing was successful with semantic-release v25.0.1.